### PR TITLE
Add conditional logic for PHP 7/8 interoperability

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -71,7 +71,12 @@ class extension_upload_fix_jpeg_orientation extends Extension
 
             if ( $img !== false ) {
                 imagejpeg($img, $tmp_file, 100);
-                imagedestroy($img);
+
+                if (class_exists('GdImage') && $img instanceof GdImage) {
+                    unset($img);
+                } elseif (is_resource($img)) {
+                    imagedestroy($img);
+                }
             }
         }
     }

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -13,6 +13,9 @@
         </author>
     </authors>
     <releases>
+        <release version="1.0.4" date="2025-11-27" min="2.7.0">
+            - added conditional `imagedestroy()`/`unset()` logic for PHP 7/8 interoperability
+        </release>
         <release version="1.0.3" date="2025-05-15" min="2.7.0">
             - added vertically flip
         </release>


### PR DESCRIPTION
- Added conditional `imagedestroy()`/`unset()` logic for PHP 7/8 interoperability